### PR TITLE
Added touch event support

### DIFF
--- a/src/svg.resize.js
+++ b/src/svg.resize.js
@@ -306,11 +306,6 @@
                 };
         }
 
-        // Emit an event to say we have changed.
-        this._calc = this.calc;
-        this.calc = function(diffX, diffY) { _this.el.fire('resizing'); return _this._calc(diffX, diffY); }
-        this.el.fire('resizing');
-
         // When resizing started, we have to register events for...
         // Touches.
         SVG.on(window, 'touchmove.resize', function(e) {
@@ -342,8 +337,7 @@
         // Calculate the difference between the mouseposition at start and now
         var txPt = this._extractPosition(event);
         var p = this.transformPoint(txPt.x, txPt.y);
-
-        //var p = this.transformPoint(event.clientX, event.clientY);
+	
         var diffX = p.x - this.parameters.p.x,
             diffY = p.y - this.parameters.p.y;
 
@@ -351,6 +345,9 @@
 
         // Calculate the new position and height / width of the element
         this.calc(diffX, diffY);
+
+	// Emit an event to say we have changed.
+        this.el.fire('resizing', [diffX, diffY]);
     };
 
     // Is called on mouseup.

--- a/src/svg.resize.js
+++ b/src/svg.resize.js
@@ -306,6 +306,11 @@
                 };
         }
 
+        // Emit an event to say we have changed.
+        this._calc = this.calc;
+        this.calc = function(diffX, diffY) { _this.el.fire('resizing'); return _this._calc(diffX, diffY); }
+        this.el.fire('resizing');
+
         // When resizing started, we have to register events for...
         // Touches.
         SVG.on(window, 'touchmove.resize', function(e) {

--- a/src/svg.resize.js
+++ b/src/svg.resize.js
@@ -337,7 +337,7 @@
         // Calculate the difference between the mouseposition at start and now
         var txPt = this._extractPosition(event);
         var p = this.transformPoint(txPt.x, txPt.y);
-	
+
         var diffX = p.x - this.parameters.p.x,
             diffY = p.y - this.parameters.p.y;
 
@@ -346,8 +346,8 @@
         // Calculate the new position and height / width of the element
         this.calc(diffX, diffY);
 
-	// Emit an event to say we have changed.
-        this.el.fire('resizing', [diffX, diffY]);
+       // Emit an event to say we have changed.
+        this.el.fire('resizing', {dx: diffX, dy: diffY, event: event});
     };
 
     // Is called on mouseup.


### PR DESCRIPTION
Hey, 

I have added touch event support for this and also in svg.select.js. I've tested in the browser emulation and in the iPad air, but a double-check will be good.  This only uses the first touch point.

Should address: https://github.com/Fuzzyma/svg.resize.js/issues/7